### PR TITLE
Update runc to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.2.0+1.1.0
+
+- **BREAKING**: `runc_checksum` isn't a static sha256 sum anymore. It's pointing to the `sha256sum` URL now of a specific release. So it doesn't needs to be adjusted anymore with every new release. The task just downloads the `runc.sha256sum` file and compares checksums.
+- update `runc_version` to `1.1.0`
+- add Molecule verification via `molecule verify -s kvm`
+- add Molecule prepare step
+- add `CHANGELOG.md`
+
+## 0.1.0+1.0.2
+
+- initial commit

--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@ ansible-role-runc
 
 Ansible role to install [runc](https://github.com/opencontainers/runc). `runc` is a CLI tool for spawning and [running](https://github.com/opencontainers/runc#using-runc) containers on Linux according to the OCI specification.
 
+Changelog
+---------
+
+see [CHANGELOG](https://github.com/githubixx/ansible-role-runc/blob/master/CHANGELOG.md)
+
 Role Variables
 --------------
 
 ```yaml
 # runc version to install
-runc_version: "1.0.2"
+runc_version: "1.1.0"
 
 # Where to install "runc" binaries.
 runc_bin_directory: "/usr/local/bin"
@@ -31,8 +36,8 @@ runc_archive: "runc.{{ runc_arch }}"
 # The runc download URL (normally no need to change it)
 runc_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/{{ runc_archive }}"
 
-# SHA256 checksum (see: https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.sha256sum)
-runc_checksum: "sha256:44d1ba01a286aaf0b31b4be9c6abc20deab0653d44ecb0d93b4d0d20eac3e0b6"
+# SHA256 checksum (normally no need to change it / see: https://github.com/opencontainers/runc/releases)
+runc_checksum: "sha256:https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.sha256sum"
 ```
 
 Example Playbook
@@ -55,7 +60,11 @@ Afterwards molecule can be executed:
 molecule converge -s kvm
 ```
 
-This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `runc`.
+This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `runc`. A small verification step is also included:
+
+```bash
+molecule verify -s kvm
+```
 
 To clean up run
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # runc version to install
-runc_version: "1.0.2"
+runc_version: "1.1.0"
 
 # Where to install "runc" binaries.
 runc_bin_directory: "/usr/local/bin"
@@ -23,5 +23,5 @@ runc_archive: "runc.{{ runc_arch }}"
 # The runc download URL (normally no need to change it)
 runc_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/{{ runc_archive }}"
 
-# SHA256 checksum (see: https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.sha256sum)
-runc_checksum: "sha256:44d1ba01a286aaf0b31b4be9c6abc20deab0653d44ecb0d93b4d0d20eac3e0b6"
+# SHA256 checksum (normally no need to change it / see: https://github.com/opencontainers/runc/releases)
+runc_checksum: "sha256:https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.sha256sum"

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -1,31 +1,6 @@
 ---
-# Copyright (C) 2021 Robert Wimmer
+# Copyright (C) 2021-2022 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-- hosts: all
-  remote_user: vagrant
-  become: true
-  gather_facts: true
-  tasks:
-    - block:
-      - name: (Archlinux) Init pacman
-        raw: |
-          pacman-key --init
-          pacman-key --populate archlinux
-        changed_when: false
-        ignore_errors: true
-
-      - name: (Archlinux) Update pacman cache
-        pacman:
-          update_cache: yes
-        changed_when: false
-      when: ansible_distribution|lower == 'archlinux'
-
-    - name: (Ubuntu) Update APT package cache
-      apt:
-        update_cache: "true"
-        cache_valid_time: 3600
-      when: ansible_distribution|lower == 'ubuntu'
 
 - hosts: all
   remote_user: vagrant

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -17,6 +17,8 @@ driver:
 platforms:
   - name: test-runc-ubuntu2004
     box: generic/ubuntu2004
+    groups:
+      - ubuntu
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -24,6 +26,8 @@ platforms:
         ip: 192.168.10.10
   - name: test-runc-ubuntu1804
     box: generic/ubuntu1804
+    groups:
+      - ubuntu
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -31,6 +35,8 @@ platforms:
         ip: 192.168.10.20
   - name: test-runc-arch
     box: archlinux/archlinux
+    groups:
+      - archlinux
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -53,4 +59,4 @@ scenario:
 
 verifier:
   name: ansible
-  enabled: False
+  enabled: true

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -1,0 +1,29 @@
+---
+# Copyright (C) 2021-2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: archlinux
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Init pacman
+      raw: |
+        pacman-key --init
+        pacman-key --populate archlinux
+      changed_when: false
+      failed_when: false
+
+    - name: Update pacman cache
+      pacman:
+        update_cache: true
+
+- hosts: ubuntu
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Update APT package cache
+      apt:
+        update_cache: true
+        cache_valid_time: 3600

--- a/molecule/kvm/verify.yml
+++ b/molecule/kvm/verify.yml
@@ -1,0 +1,18 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Verify setup
+  hosts: all
+  vars:
+    expected_output: "1.1.0"
+  tasks:
+    - name: Execute runc version to capture output
+      command: runc --version
+      register: runc_version_output
+      changed_when: false
+
+    - name: Ensure runc version output contains correct version string
+      assert:
+        that:
+          - "expected_output in runc_version_output.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   get_url:
     url: "{{ runc_url }}"
     dest: "{{ runc_bin_directory }}/runc"
-    checksum: "sha256:44d1ba01a286aaf0b31b4be9c6abc20deab0653d44ecb0d93b4d0d20eac3e0b6"
+    checksum: "{{ runc_checksum }}"
     mode: "{{ runc_binary_mode }}"
     owner: "{{ runc_owner | default(omit) }}"
     group: "{{ runc_group | default(omit) }}"


### PR DESCRIPTION
- **BREAKING**: `runc_checksum` isn't a static sha256 sum anymore. It's pointing to the `sha256sum` URL now of a specific release. So it doesn't needs to be adjusted anymore with every new release. The task just downloads the `runc.sha256sum` file and compares checksums.
- update `runc_version` to `1.1.0`
- add Molecule verification via `molecule verify -s kvm`
- add Molecule prepare step
- add `CHANGELOG.md`