### PR TITLE
0.2.1+1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1+1.1.4
+
+- update `runc_version` to `1.1.4`
+
 ## 0.2.0+1.1.0
 
 - **BREAKING**: `runc_checksum` isn't a static sha256 sum anymore. It's pointing to the `sha256sum` URL now of a specific release. So it doesn't needs to be adjusted anymore with every new release. The task just downloads the `runc.sha256sum` file and compares checksums.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 
 ```yaml
 # runc version to install
-runc_version: "1.1.0"
+runc_version: "1.1.4"
 
 # Where to install "runc" binaries.
 runc_bin_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # runc version to install
-runc_version: "1.1.0"
+runc_version: "1.1.4"
 
 # Where to install "runc" binaries.
 runc_bin_directory: "/usr/local/bin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,9 @@
+---
 galaxy_info:
   author: Robert Wimmer
   description: Ansible role to install runc
   license: GPLv3
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   role_name: runc
   namespace: githubixx
   platforms:

--- a/molecule/kvm/verify.yml
+++ b/molecule/kvm/verify.yml
@@ -5,7 +5,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "1.1.0"
+    expected_output: "1.1.4"
   tasks:
     - name: Execute runc version to capture output
       command: runc --version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Downloading runc
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ runc_url }}"
     dest: "{{ runc_bin_directory }}/runc"
     checksum: "{{ runc_checksum }}"


### PR DESCRIPTION
- update `runc_version` to `1.1.4`
- use FQDN for Ansible modules
- `min_ansible_version` value should be string
- change expected runc version in molecule/kvm/verify.yml