### PR TITLE
0.5.0+1.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0+1.1.10
+
+- change default value of `runc_bin_directory` from `/usr/local/bin` to `/usr/local/sbin`
+
 ## 0.4.1+1.1.10
 
 - update runc to `1.1.9`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Role Variables
 runc_version: "1.1.10"
 
 # Where to install "runc" binaries.
-runc_bin_directory: "/usr/local/bin"
+runc_bin_directory: "/usr/local/sbin"
 
 # Owner/group of "runc" binary. If the variables are not set
 # the resulting binary will be owned by the current user.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 runc_version: "1.1.10"
 
 # Where to install "runc" binaries.
-runc_bin_directory: "/usr/local/bin"
+runc_bin_directory: "/usr/local/sbin"
 
 # Owner/group of "runc" binary. If the variables are not set
 # the resulting binary will be owned by the current user.


### PR DESCRIPTION
- change default value of `runc_bin_directory` from `/usr/local/bin` to `/usr/local/sbin`