### PR TITLE
0.7.0+1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - **UPDATE**
   - update runc to `1.3.0`
 
+- **MOLECULE**
+  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+  - Install `openssl` package for Archlinux
+  - Removed Ubuntu 20.04 because reached end of life
+  - Removed 'Upgrade the whole system' task
+
 ## 0.6.0+1.2.4
 
 - **UPDATE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 0.7.0+1.3.0
+
+- **UPDATE**
+  - update runc to `1.3.0`
+
 ## 0.6.0+1.2.4
 
 - **UPDATE**

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-runc/blob/master/
 - **UPDATE**
   - update runc to `1.3.0`
 
+- **MOLECULE**
+  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+  - Install `openssl` package for Archlinux
+  - Removed Ubuntu 20.04 because reached end of life
+  - Removed 'Upgrade the whole system' task
+
 ## 0.6.0+1.2.4
 
 - **UPDATE**

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-runc/blob/master/
 
 **Recent changes:**
 
+## 0.7.0+1.3.0
+
+- **UPDATE**
+  - update runc to `1.3.0`
+
 ## 0.6.0+1.2.4
 
 - **UPDATE**
@@ -24,26 +29,6 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-runc/blob/master/
 
 - **UPDATE**
   - update `CHANGELOG.md`
-
-## 0.5.4+1.1.14
-
-- **UPDATE**
-  - update runc to `1.1.14`
-
-## 0.5.3+1.1.13
-
-- **UPDATE**
-  - update runc to `1.1.13`
-
-### OTHER
-
-- add support for Ubuntu 24.04
-
-## 0.5.2+1.1.12
-
-### UPDATE
-
-- update runc to `1.1.12`
 
 ## Installation
 
@@ -61,14 +46,14 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-runc/blob/master/
 roles:
   - name: githubixx.runc
     src: https://github.com/githubixx/ansible-role-runc.git
-    version: 0.6.0+1.2.4
+    version: 0.7.0+1.3.0
 ```
 
 ## Role Variables
 
 ```yaml
 # runc version to install
-runc_version: "1.2.4"
+runc_version: "1.3.0"
 
 # Where to install "runc" binaries.
 runc_bin_directory: "/usr/local/sbin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # runc version to install
-runc_version: "1.2.4"
+runc_version: "1.3.0"
 
 # Where to install "runc" binaries.
 runc_bin_directory: "/usr/local/sbin"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,17 +12,6 @@ driver:
     type: libvirt
 
 platforms:
-  - name: test-runc-ubuntu2004
-    box: generic/ubuntu2004
-    memory: 2048
-    cpus: 2
-    groups:
-      - ubuntu
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.10
   - name: test-runc-ubuntu2204
     box: alvistack/ubuntu-22.04
     memory: 2048
@@ -46,7 +35,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-runc-arch
-    box: archlinux/archlinux
+    box: generic/arch
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -29,7 +29,7 @@
 
     - name: Install Python
       ansible.builtin.raw: |
-        pacman -S --noconfirm python
+        pacman -S --noconfirm python openssl
       args:
         executable: /bin/bash
       changed_when: false

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -20,13 +20,6 @@
         pacman -Sy
       changed_when: false
 
-    - name: Upgrade the whole system
-      ansible.builtin.raw: |
-        pacman --noconfirm -Su
-      args:
-        executable: /bin/bash
-      changed_when: false
-
     - name: Install Python
       ansible.builtin.raw: |
         pacman -S --noconfirm python openssl

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,7 +5,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "1.2.4"
+    expected_output: "1.3.0"
   tasks:
     - name: Execute runc version to capture output
       ansible.builtin.command: runc --version


### PR DESCRIPTION
## 0.7.0+1.3.0

- **UPDATE**
  - update runc to `1.3.0`

- **MOLECULE**
  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
  - Install `openssl` package for Archlinux
  - Removed Ubuntu 20.04 because reached end of life
  - Removed 'Upgrade the whole system' task
